### PR TITLE
feat: add PR preview deployments for draft blog posts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,4 +18,9 @@ jobs:
       - uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
-      - run: uv run mkdocs gh-deploy --force
+      - run: uv run mkdocs build
+      - uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./site
+          keep_files: true

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,0 +1,74 @@
+name: preview
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, closed]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  deploy-preview:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+
+      - name: Build and deploy preview
+        if: github.event.action != 'closed'
+        run: |
+          sed -i.bak "s|site_url:.*|site_url: https://williambdean.github.io/pr-${{ github.event.number }}/|" mkdocs.yml
+          uv run mkdocs build
+          mv mkdocs.yml.bak mkdocs.yml
+
+      - name: Deploy to gh-pages
+        if: github.event.action != 'closed'
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./site
+          destination_dir: pr-${{ github.event.number }}
+          keep_files: true
+
+      - name: Clean up preview on close
+        if: github.event.action == 'closed'
+        run: |
+          git fetch origin gh-pages
+          git checkout gh-pages
+          rm -rf pr-${{ github.event.number }}
+          git add -A
+          git diff --quiet && git diff --staged --quiet || \
+            git -c user.name="github-actions[bot]" -c user.email="41898282+github-actions[bot]@users.noreply.github.com" \
+              commit -m "Clean up preview for PR #${{ github.event.number }}"
+          git push origin gh-pages
+
+      - name: Update PR body with preview URL
+        if: github.event.action != 'closed'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const previewUrl = `https://williambdean.github.io/pr-${context.issue.number}/`;
+            const previewSection = `\n---\n### Preview\n\nA live preview of this branch is deployed at: **[${previewUrl}](${previewUrl})**`;
+
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number,
+            });
+
+            let body = pr.body || '';
+
+            // Remove any existing preview section
+            body = body.replace(/\n---\n### Preview\n.*?(?=\n---|$)/s, '');
+
+            await github.rest.pulls.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number,
+              body: body + previewSection,
+            });


### PR DESCRIPTION
Adds a preview workflow that deploys MkDocs builds from PR branches
to `pr-<number>/` on `gh-pages`.

Now you can open a PR for a draft blog post and share the live preview URL
with coworkers: `https://williambdean.github.io/pr-<number>/`

The PR body is automatically updated with the preview link on each push.
When the PR is merged or closed, the preview directory is cleaned up.

## How it works

- **ci.yml** — changed from `mkdocs gh-deploy --force` (which wipes everything)
  to `mkdocs build` + `peaceiris/actions-gh-pages` with `keep_files: true`,
  so PR preview subdirectories survive production deploys.
- **preview.yml** (new) — triggers on PR events. Builds with an overridden
  `site_url`, deploys to `pr-<number>/`, updates the PR body, and cleans up
  on close.

## Testing this PR

Open the PR, wait for the preview workflow to complete, then check the
PR body for the preview link.
---
### Preview

A live preview of this branch is deployed at: **[https://williambdean.github.io/pr-18/](https://williambdean.github.io/pr-18/)**